### PR TITLE
iframes are now named as the sanbox's url

### DIFF
--- a/lib/oasis/iframe_adapter.js
+++ b/lib/oasis/iframe_adapter.js
@@ -12,6 +12,7 @@ var IframeAdapter = extend(BaseAdapter, {
         iframe = document.createElement('iframe'),
         oasisURL = options.oasisURL || 'oasis.js.html';
 
+    ifraame.name = sandbox.options.url;
     iframe.sandbox = 'allow-same-origin allow-scripts';
     iframe.seamless = true;
     iframe.src = 'about:blank'


### PR DESCRIPTION
This drastically improves dev ergonomics by enabling the dev tools
to label the iframe with something with meaning.
