### PR TITLE
Nested sandboxes reuse `oasisURL` as default.

### DIFF
--- a/dist/oasis.js.html
+++ b/dist/oasis.js.html
@@ -595,8 +595,8 @@ define("rsvp",
   });
 
 define("oasis",
-  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
+  ["oasis/util", "oasis/message_channel", "oasis/ports", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, configuration, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var verifySandbox = __dependency1__.verifySandbox;
@@ -650,6 +650,8 @@ define("oasis",
     };
     Oasis.reset();
 
+    Oasis.config = configuration;
+
 
     /**
       This registers a sandbox type inside of the containing environment so that
@@ -682,8 +684,8 @@ define("oasis",
 
     return Oasis;
   });define("oasis/base_adapter",
-  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger"],
-  function(__dependency1__, __dependency2__, __dependency3__, Logger) {
+  ["oasis/util", "oasis/ports", "oasis/message_channel", "oasis/logger", "oasis/config"],
+  function(__dependency1__, __dependency2__, __dependency3__, Logger, configuration) {
     "use strict";
     var mustImplement = __dependency1__.mustImplement;
     var handlers = __dependency2__.handlers;
@@ -704,6 +706,10 @@ define("oasis",
 
     BaseAdapter.prototype = {
       loadScripts: mustImplement('BaseAdapter', 'loadScripts'),
+
+      oasisURL: function(sandbox) {
+        return sandbox.options.oasisURL || configuration.oasisURL || 'oasis.js.html';
+      },
 
       createChannel: function(sandbox) {
         var channel = new PostMessageMessageChannel();
@@ -732,6 +738,8 @@ define("oasis",
           if (!event.data.isOasisInitialization) { return; }
 
           Logger.log("Sandbox initializing.");
+
+          configuration.oasisURL = event.data.oasisURL;
 
           receiver.removeEventListener('message', initializeOasisSandbox);
           adapter.loadScripts(event.data.base, event.data.scriptURLs);
@@ -763,12 +771,26 @@ define("oasis",
           isOasisInitialization: true,
           capabilities: sandbox.capabilities,
           base: getBase(),
-          scriptURLs: scriptURLs
+          scriptURLs: scriptURLs,
+          oasisURL: this.oasisURL(sandbox)
         };
       }
     }
 
     return BaseAdapter;
+  });define("oasis/config",
+  [],
+  function() {
+    "use strict";
+    /**
+      Stores Oasis configuration.  Options include:
+
+      `oasisURL` - the default URL to use for sandboxes.
+    */
+    var configuration = {
+    };
+
+    return configuration;
   });define("oasis/connect",
   ["oasis/util", "oasis/ports", "rsvp", "oasis/logger", "oasis/state", "exports"],
   function(__dependency1__, __dependency2__, RSVP, Logger, State, __exports__) {
@@ -874,7 +896,7 @@ define("oasis",
       initializeSandbox: function(sandbox) {
         var options = sandbox.options,
             iframe = document.createElement('iframe'),
-            oasisURL = options.oasisURL || 'oasis.js.html';
+            oasisURL = this.oasisURL(sandbox);
 
         iframe.name = sandbox.options.url;
         iframe.sandbox = 'allow-same-origin allow-scripts';
@@ -1186,8 +1208,8 @@ define("oasis",
     __exports__.handlers = handlers;
     __exports__.ports = ports;
   });define("oasis/sandbox",
-  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/iframe_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, OasisState, iframeAdapter) {
+  ["oasis/util", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/iframe_adapter"],
+  function(__dependency1__, __dependency2__, RSVP, Logger, State, configuration, iframeAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var OasisPort = __dependency2__.OasisPort;
@@ -1198,7 +1220,7 @@ define("oasis",
       this.wiretaps = [];
 
       // Generic capabilities code
-      var pkg = OasisState.packages[options.url];
+      var pkg = State.packages[options.url];
 
       var capabilities = options.capabilities;
       if (!capabilities) {
@@ -1580,7 +1602,7 @@ define("oasis",
 
     var WebworkerAdapter = extend(BaseAdapter, {
       initializeSandbox: function(sandbox) {
-        var oasisURL = sandbox.options.oasisURL || 'oasis.js.html';
+        var oasisURL = this.oasisURL(sandbox);
         var worker = new Worker(oasisURL);
         sandbox.worker = worker;
         return new RSVP.Promise(function (resolve, reject) {

--- a/lib/oasis.js
+++ b/lib/oasis.js
@@ -2,6 +2,7 @@ import "rsvp" as RSVP;
 import "oasis/logger" as Logger;
 import { assert, verifySandbox } from "oasis/util";
 import "oasis/state" as State;
+import "oasis/config" as configuration;
 import "oasis/sandbox" as Sandbox;
 import "oasis/sandbox_init" as initializeSandbox;
 
@@ -52,6 +53,8 @@ Oasis.reset = function() {
   Oasis.consumers = State.consumers;
 };
 Oasis.reset();
+
+Oasis.config = configuration;
 
 
 /**

--- a/lib/oasis/base_adapter.js
+++ b/lib/oasis/base_adapter.js
@@ -1,6 +1,7 @@
 import "oasis/logger" as Logger;
 import { mustImplement } from "oasis/util";
 
+import "oasis/config" as configuration;
 import { handlers } from "oasis/ports";
 import { PostMessagePort, PostMessageMessageChannel } from "oasis/message_channel";
 
@@ -17,6 +18,10 @@ function BaseAdapter() {
 
 BaseAdapter.prototype = {
   loadScripts: mustImplement('BaseAdapter', 'loadScripts'),
+
+  oasisURL: function(sandbox) {
+    return sandbox.options.oasisURL || configuration.oasisURL || 'oasis.js.html';
+  },
 
   createChannel: function(sandbox) {
     var channel = new PostMessageMessageChannel();
@@ -45,6 +50,8 @@ BaseAdapter.prototype = {
       if (!event.data.isOasisInitialization) { return; }
 
       Logger.log("Sandbox initializing.");
+
+      configuration.oasisURL = event.data.oasisURL;
 
       receiver.removeEventListener('message', initializeOasisSandbox);
       adapter.loadScripts(event.data.base, event.data.scriptURLs);
@@ -76,7 +83,8 @@ BaseAdapter.prototype = {
       isOasisInitialization: true,
       capabilities: sandbox.capabilities,
       base: getBase(),
-      scriptURLs: scriptURLs
+      scriptURLs: scriptURLs,
+      oasisURL: this.oasisURL(sandbox)
     };
   }
 }

--- a/lib/oasis/config.js
+++ b/lib/oasis/config.js
@@ -1,0 +1,9 @@
+/**
+  Stores Oasis configuration.  Options include:
+
+  `oasisURL` - the default URL to use for sandboxes.
+*/
+var configuration = {
+};
+
+export = configuration;

--- a/lib/oasis/iframe_adapter.js
+++ b/lib/oasis/iframe_adapter.js
@@ -10,7 +10,7 @@ var IframeAdapter = extend(BaseAdapter, {
   initializeSandbox: function(sandbox) {
     var options = sandbox.options,
         iframe = document.createElement('iframe'),
-        oasisURL = options.oasisURL || 'oasis.js.html';
+        oasisURL = this.oasisURL(sandbox);
 
     iframe.name = sandbox.options.url;
     iframe.sandbox = 'allow-same-origin allow-scripts';

--- a/lib/oasis/sandbox.js
+++ b/lib/oasis/sandbox.js
@@ -3,7 +3,8 @@ import "oasis/logger" as Logger;
 import { assert } from "oasis/util";
 
 import { OasisPort } from "oasis/message_channel";
-import "oasis/state" as OasisState;
+import "oasis/state" as State;
+import "oasis/config" as configuration;
 import "oasis/iframe_adapter" as iframeAdapter;
 
 var OasisSandbox = function(options) {
@@ -11,7 +12,7 @@ var OasisSandbox = function(options) {
   this.wiretaps = [];
 
   // Generic capabilities code
-  var pkg = OasisState.packages[options.url];
+  var pkg = State.packages[options.url];
 
   var capabilities = options.capabilities;
   if (!capabilities) {

--- a/lib/oasis/webworker_adapter.js
+++ b/lib/oasis/webworker_adapter.js
@@ -8,7 +8,7 @@ import { handlers } from "oasis/ports";
 
 var WebworkerAdapter = extend(BaseAdapter, {
   initializeSandbox: function(sandbox) {
-    var oasisURL = sandbox.options.oasisURL || 'oasis.js.html';
+    var oasisURL = this.oasisURL(sandbox);
     var worker = new Worker(oasisURL);
     sandbox.worker = worker;
     return new RSVP.Promise(function (resolve, reject) {

--- a/test/fixtures/nested_custom_oasis_url_child.js
+++ b/test/fixtures/nested_custom_oasis_url_child.js
@@ -1,0 +1,11 @@
+Oasis.connect('assertions', function(port) {
+  var href;
+
+  if (typeof location !== 'undefined') {
+    href = location.href;
+  } else {
+    href = Oasis.config.oasisURL;
+  }
+
+  port.send('checkUrl', href);
+});

--- a/test/fixtures/nested_custom_oasis_url_parent.js
+++ b/test/fixtures/nested_custom_oasis_url_parent.js
@@ -1,0 +1,15 @@
+Oasis.connect('assertions', function(port) {
+  Oasis.register({
+    url: 'fixtures/nested_custom_oasis_url_child.js',
+    capabilities: ['assertions']
+  });
+
+  var sandbox = Oasis.createSandbox({
+    url: 'fixtures/nested_custom_oasis_url_child.js',
+    services: {
+      assertions: port
+    }
+  });
+
+  sandbox.start();
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -484,6 +484,33 @@ function suite(adapter, extras) {
 
       equal( sandbox.el.name, 'fixtures/index.js', 'The iframe has a name' );
     });
+
+    test("Nested sandboxes should default `oasisURL` to the one they were given", function() {
+      expect(1);
+
+      var AssertionService = Oasis.Service.extend({
+        events: {
+          checkUrl: function (oasisURL) {
+            var expected = "oasis-custom-url.js.html";
+            start();
+            equal(oasisURL.substring(oasisURL.length - expected.length), expected, "Nested sandboxed used right oasisURL");
+          }
+        }
+      });
+
+      createSandbox({
+        url: 'fixtures/nested_custom_oasis_url_parent.js',
+        capabilities: ['assertions'],
+        services: {
+          assertions: AssertionService
+        },
+        oasisURL: '/vendor/oasis-custom-url.js.html'
+      });
+
+      stop();
+
+      sandbox.start();
+    });
   }
 
   test("When the shorthand form is used for events, they can send events", function() {
@@ -762,6 +789,7 @@ function suite(adapter, extras) {
 
     sandbox.start();
   });
+
 }
 
 suite('iframe', function() {

--- a/test/vendor/oasis-custom-url.js.html
+++ b/test/vendor/oasis-custom-url.js.html
@@ -1,0 +1,1 @@
+../../dist/oasis.js.html


### PR DESCRIPTION
This is convenient for the common case that `oasisURL` needs to be defined 
exactly once.

Nested sandboxes can still define their own default by setting
`Oasis.config.oasisURL` or create sandboxes with a specific URL.

This makes fixing tildeio/conductor.js#20 trivial.

cc @Cyril-sf
