### PR TITLE
Wrap event handlers.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
     },
 
     watch: {
-      files: ['lib/**', 'test/tests.js'],
+      files: ['lib/**', 'test/**'],
       tasks: ['shell', 'copy']
     },
 

--- a/History.md
+++ b/History.md
@@ -1,5 +1,11 @@
 ### 0.2.0
 
+- Users may supply wrappers around event handlers via `Oasis.configure`.  The
+  default wrapper simply invokes the callback directly.
+```js
+Oasis.configure('eventHandler', function (callback) { callback(); });
+```
+
 #### Breaking Changes
 
 - Request handlers may not directly return literal `undefined` values.  Such

--- a/dist/oasis.amd.js
+++ b/dist/oasis.amd.js
@@ -1,12 +1,14 @@
 define("oasis",
-  ["oasis/util", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, State, configuration, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
+  ["oasis/util", "oasis/config", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var verifySandbox = __dependency1__.verifySandbox;
-    var registerHandler = __dependency2__.registerHandler;
-    var connect = __dependency2__.connect;
-    var portFor = __dependency2__.portFor;
+    var configuration = __dependency2__.configuration;
+    var configure = __dependency2__.configure;
+    var registerHandler = __dependency3__.registerHandler;
+    var connect = __dependency3__.connect;
+    var portFor = __dependency3__.portFor;
 
 
 
@@ -51,6 +53,7 @@ define("oasis",
     Oasis.reset();
 
     Oasis.config = configuration;
+    Oasis.configure = configure;
 
 
     /**
@@ -84,15 +87,16 @@ define("oasis",
 
     return Oasis;
   });define("oasis/base_adapter",
-  ["oasis/util", "oasis/shims", "oasis/globals", "oasis/connect", "oasis/message_channel", "oasis/logger", "oasis/config"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, Logger, configuration) {
+  ["oasis/util", "oasis/shims", "oasis/config", "oasis/globals", "oasis/connect", "oasis/message_channel", "oasis/logger"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, Logger) {
     "use strict";
     var mustImplement = __dependency1__.mustImplement;
     var addEventListener = __dependency2__.addEventListener;
     var removeEventListener = __dependency2__.removeEventListener;
-    var handlers = __dependency3__.handlers;
-    var connectCapabilities = __dependency4__.connectCapabilities;
-    var PostMessageMessageChannel = __dependency5__.PostMessageMessageChannel;
+    var configuration = __dependency3__.configuration;
+    var handlers = __dependency4__.handlers;
+    var connectCapabilities = __dependency5__.connectCapabilities;
+    var PostMessageMessageChannel = __dependency6__.PostMessageMessageChannel;
 
 
     function getBase () {
@@ -142,16 +146,18 @@ define("oasis",
         function initializeOasisSandbox(event) {
           if (!event.data.isOasisInitialization) { return; }
 
-          Logger.log("Sandbox initializing.");
+          configuration.eventCallback(function () {
+            Logger.log("Sandbox initializing.");
 
-          configuration.oasisURL = event.data.oasisURL;
+            configuration.oasisURL = event.data.oasisURL;
 
-          removeEventListener(receiver, 'message', initializeOasisSandbox);
-          adapter.loadScripts(event.data.base, event.data.scriptURLs);
+            removeEventListener(receiver, 'message', initializeOasisSandbox);
+            adapter.loadScripts(event.data.base, event.data.scriptURLs);
 
-          connectCapabilities(event.data.capabilities, event.ports);
+            connectCapabilities(event.data.capabilities, event.ports);
 
-          adapter.didConnect();
+            adapter.didConnect();
+          });
         }
         addEventListener(receiver, 'message', initializeOasisSandbox);
 
@@ -174,18 +180,26 @@ define("oasis",
 
     return BaseAdapter;
   });define("oasis/config",
-  [],
-  function() {
+  ["exports"],
+  function(__exports__) {
     "use strict";
     /**
       Stores Oasis configuration.  Options include:
 
-      `oasisURL` - the default URL to use for sandboxes.
+      - `oasisURL` - the default URL to use for sandboxes.
+      - `eventCallback` - a function that wraps `message` event handlers.  By
+        default the event hanlder is simply invoked.
     */
     var configuration = {
+      eventCallback: function (callback) { callback(); }
     };
 
-    return configuration;
+    function configure(name, value) {
+      configuration[name] = value;
+    }
+
+    __exports__.configuration = configuration;
+    __exports__.configure = configure;
   });define("oasis/connect",
   ["oasis/util", "oasis/shims", "oasis/globals", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, __exports__) {
@@ -377,13 +391,14 @@ define("oasis",
     __exports__.handlers = handlers;
     __exports__.ports = ports;
   });define("oasis/iframe_adapter",
-  ["oasis/util", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, BaseAdapter) {
+  ["oasis/util", "oasis/config", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, BaseAdapter) {
     "use strict";
     var extend = __dependency1__.extend;
-    var addEventListener = __dependency2__.addEventListener;
-    var removeEventListener = __dependency2__.removeEventListener;
-    var a_map = __dependency2__.a_map;
+    var configuration = __dependency2__.configuration;
+    var addEventListener = __dependency3__.addEventListener;
+    var removeEventListener = __dependency3__.removeEventListener;
+    var a_map = __dependency3__.a_map;
 
 
     var IframeAdapter = extend(BaseAdapter, {
@@ -405,12 +420,14 @@ define("oasis",
         }
 
         iframe.oasisLoadHandler = function () {
-          removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
+          configuration.eventCallback(function () {
+            removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
-          sandbox.iframeLoaded = true;
+            sandbox.iframeLoaded = true;
 
-          Logger.log("iframe loading oasis");
-          iframe.contentWindow.location.href = oasisURL;
+            Logger.log("iframe loading oasis");
+            iframe.contentWindow.location.href = oasisURL;
+          });
         };
         addEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
@@ -421,9 +438,10 @@ define("oasis",
             if( event.source !== iframe.contentWindow ) {return;}
             removeEventListener(window, 'message', iframe.initializationHandler);
 
-
-            Logger.log("iframe sandbox initialized");
-            resolve(sandbox);
+            configuration.eventCallback(function () {
+              Logger.log("iframe sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(window, 'message', iframe.initializationHandler);
         });
@@ -437,8 +455,10 @@ define("oasis",
             if( event.source !== iframe.contentWindow ) {return;}
             removeEventListener(window, 'message', iframe.loadHandler);
 
-            Logger.log("iframe sandbox loaded");
-            resolve(sandbox);
+            configuration.eventCallback(function () {
+              Logger.log("iframe sandbox loaded");
+              resolve(sandbox);
+            });
           };
           addEventListener(window, 'message', iframe.loadHandler);
         });
@@ -544,12 +564,13 @@ define("oasis",
 
     return logger;
   });define("oasis/message_channel",
-  ["oasis/util", "rsvp", "oasis/state", "exports"],
-  function(__dependency1__, RSVP, OasisState, __exports__) {
+  ["oasis/util", "oasis/config", "rsvp", "oasis/state", "exports"],
+  function(__dependency1__, __dependency2__, RSVP, OasisState, __exports__) {
     "use strict";
     var extend = __dependency1__.extend;
     var mustImplement = __dependency1__.mustImplement;
     var rsvpErrorHandler = __dependency1__.rsvpErrorHandler;
+    var configuration = __dependency2__.configuration;
 
     /**
       OasisPort is an interface that adapters can use to implement ports.
@@ -760,7 +781,9 @@ define("oasis",
       on: function(eventName, callback, binding) {
         function wrappedCallback(event) {
           if (event.data.type === eventName) {
-            callback.call(binding, event.data.data);
+            configuration.eventCallback(function () {
+              return callback.call(binding, event.data.data);
+            });
           }
         }
 
@@ -769,9 +792,13 @@ define("oasis",
       },
 
       all: function(callback, binding) {
-        this.port.addEventListener('message', function(event) {
-          callback.call(binding, event.data.type, event.data.data);
-        });
+        function wrappedCallback(event) {
+          configuration.eventCallback(function () {
+            callback.call(binding, event.data.type, event.data.data);
+          });
+        }
+
+        this.port.addEventListener('message', wrappedCallback);
       },
 
       off: function(eventName, callback) {
@@ -813,14 +840,15 @@ define("oasis",
     __exports__.PostMessageMessageChannel = PostMessageMessageChannel;
     __exports__.PostMessagePort = PostMessagePort;
   });define("oasis/sandbox",
-  ["oasis/util", "oasis/shims", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/iframe_adapter"],
-  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, State, configuration, iframeAdapter) {
+  ["oasis/util", "oasis/shims", "oasis/message_channel", "oasis/config", "rsvp", "oasis/logger", "oasis/state", "oasis/iframe_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, iframeAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var rsvpErrorHandler = __dependency1__.rsvpErrorHandler;
     var a_forEach = __dependency2__.a_forEach;
     var a_reduce = __dependency2__.a_reduce;
     var OasisPort = __dependency3__.OasisPort;
+    var configuration = __dependency4__.configuration;
 
 
     var OasisSandbox = function(options) {
@@ -1364,9 +1392,11 @@ define("oasis",
     __exports__.addEventListener = addEventListener;
     __exports__.removeEventListener = removeEventListener;
   });define("oasis/state",
-  [],
-  function() {
+  ["oasis/config"],
+  function(__dependency1__) {
     "use strict";
+    var configuration = __dependency1__.configuration;
+
     function State () {
       this.reset();
     };
@@ -1378,6 +1408,8 @@ define("oasis",
 
       this.consumers = {};
       this.services = [];
+
+      configuration.eventCallback = function (callback) { callback(); };
     }
 
     return new State;
@@ -1444,13 +1476,14 @@ define("oasis",
     __exports__.verifySandbox = verifySandbox;
     __exports__.rsvpErrorHandler = rsvpErrorHandler;
   });define("oasis/webworker_adapter",
-  ["oasis/util", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, BaseAdapter) {
+  ["oasis/util", "oasis/config", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, BaseAdapter) {
     "use strict";
     var extend = __dependency1__.extend;
-    var a_forEach = __dependency2__.a_forEach;
-    var addEventListener = __dependency2__.addEventListener;
-    var removeEventListener = __dependency2__.removeEventListener;
+    var configuration = __dependency2__.configuration;
+    var a_forEach = __dependency3__.a_forEach;
+    var addEventListener = __dependency3__.addEventListener;
+    var removeEventListener = __dependency3__.removeEventListener;
 
 
     var WebworkerAdapter = extend(BaseAdapter, {
@@ -1461,22 +1494,26 @@ define("oasis",
 
         sandbox.promise = new RSVP.Promise( function(resolve, reject) {
           worker.initializationHandler = function (event) {
-            if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
-            removeEventListener(worker, 'message', worker.initializationHandler);
+            configuration.eventCallback(function () {
+              if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
+              removeEventListener(worker, 'message', worker.initializationHandler);
 
-            Logger.log("worker sandbox initialized");
-            resolve(sandbox);
+              Logger.log("worker sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(worker, 'message', worker.initializationHandler);
         });
 
         return new RSVP.Promise(function (resolve, reject) {
           worker.loadHandler = function (event) {
-            if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
-            removeEventListener(worker, 'message', worker.loadHandler);
+            configuration.eventCallback(function () {
+              if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
+              removeEventListener(worker, 'message', worker.loadHandler);
 
-            Logger.log("worker sandbox initialized");
-            resolve(sandbox);
+              Logger.log("worker sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(worker, 'message', worker.loadHandler);
         });

--- a/dist/oasis.js.html
+++ b/dist/oasis.js.html
@@ -595,14 +595,16 @@ define("rsvp",
   });
 
 define("oasis",
-  ["oasis/util", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, State, configuration, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
+  ["oasis/util", "oasis/config", "oasis/connect", "rsvp", "oasis/logger", "oasis/state", "oasis/sandbox", "oasis/sandbox_init", "oasis/service", "oasis/iframe_adapter", "oasis/webworker_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var verifySandbox = __dependency1__.verifySandbox;
-    var registerHandler = __dependency2__.registerHandler;
-    var connect = __dependency2__.connect;
-    var portFor = __dependency2__.portFor;
+    var configuration = __dependency2__.configuration;
+    var configure = __dependency2__.configure;
+    var registerHandler = __dependency3__.registerHandler;
+    var connect = __dependency3__.connect;
+    var portFor = __dependency3__.portFor;
 
 
 
@@ -647,6 +649,7 @@ define("oasis",
     Oasis.reset();
 
     Oasis.config = configuration;
+    Oasis.configure = configure;
 
 
     /**
@@ -680,15 +683,16 @@ define("oasis",
 
     return Oasis;
   });define("oasis/base_adapter",
-  ["oasis/util", "oasis/shims", "oasis/globals", "oasis/connect", "oasis/message_channel", "oasis/logger", "oasis/config"],
-  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, Logger, configuration) {
+  ["oasis/util", "oasis/shims", "oasis/config", "oasis/globals", "oasis/connect", "oasis/message_channel", "oasis/logger"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, __dependency5__, __dependency6__, Logger) {
     "use strict";
     var mustImplement = __dependency1__.mustImplement;
     var addEventListener = __dependency2__.addEventListener;
     var removeEventListener = __dependency2__.removeEventListener;
-    var handlers = __dependency3__.handlers;
-    var connectCapabilities = __dependency4__.connectCapabilities;
-    var PostMessageMessageChannel = __dependency5__.PostMessageMessageChannel;
+    var configuration = __dependency3__.configuration;
+    var handlers = __dependency4__.handlers;
+    var connectCapabilities = __dependency5__.connectCapabilities;
+    var PostMessageMessageChannel = __dependency6__.PostMessageMessageChannel;
 
 
     function getBase () {
@@ -738,16 +742,18 @@ define("oasis",
         function initializeOasisSandbox(event) {
           if (!event.data.isOasisInitialization) { return; }
 
-          Logger.log("Sandbox initializing.");
+          configuration.eventCallback(function () {
+            Logger.log("Sandbox initializing.");
 
-          configuration.oasisURL = event.data.oasisURL;
+            configuration.oasisURL = event.data.oasisURL;
 
-          removeEventListener(receiver, 'message', initializeOasisSandbox);
-          adapter.loadScripts(event.data.base, event.data.scriptURLs);
+            removeEventListener(receiver, 'message', initializeOasisSandbox);
+            adapter.loadScripts(event.data.base, event.data.scriptURLs);
 
-          connectCapabilities(event.data.capabilities, event.ports);
+            connectCapabilities(event.data.capabilities, event.ports);
 
-          adapter.didConnect();
+            adapter.didConnect();
+          });
         }
         addEventListener(receiver, 'message', initializeOasisSandbox);
 
@@ -770,18 +776,26 @@ define("oasis",
 
     return BaseAdapter;
   });define("oasis/config",
-  [],
-  function() {
+  ["exports"],
+  function(__exports__) {
     "use strict";
     /**
       Stores Oasis configuration.  Options include:
 
-      `oasisURL` - the default URL to use for sandboxes.
+      - `oasisURL` - the default URL to use for sandboxes.
+      - `eventCallback` - a function that wraps `message` event handlers.  By
+        default the event hanlder is simply invoked.
     */
     var configuration = {
+      eventCallback: function (callback) { callback(); }
     };
 
-    return configuration;
+    function configure(name, value) {
+      configuration[name] = value;
+    }
+
+    __exports__.configuration = configuration;
+    __exports__.configure = configure;
   });define("oasis/connect",
   ["oasis/util", "oasis/shims", "oasis/globals", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "exports"],
   function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, __exports__) {
@@ -973,13 +987,14 @@ define("oasis",
     __exports__.handlers = handlers;
     __exports__.ports = ports;
   });define("oasis/iframe_adapter",
-  ["oasis/util", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, BaseAdapter) {
+  ["oasis/util", "oasis/config", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, BaseAdapter) {
     "use strict";
     var extend = __dependency1__.extend;
-    var addEventListener = __dependency2__.addEventListener;
-    var removeEventListener = __dependency2__.removeEventListener;
-    var a_map = __dependency2__.a_map;
+    var configuration = __dependency2__.configuration;
+    var addEventListener = __dependency3__.addEventListener;
+    var removeEventListener = __dependency3__.removeEventListener;
+    var a_map = __dependency3__.a_map;
 
 
     var IframeAdapter = extend(BaseAdapter, {
@@ -1001,12 +1016,14 @@ define("oasis",
         }
 
         iframe.oasisLoadHandler = function () {
-          removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
+          configuration.eventCallback(function () {
+            removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
-          sandbox.iframeLoaded = true;
+            sandbox.iframeLoaded = true;
 
-          Logger.log("iframe loading oasis");
-          iframe.contentWindow.location.href = oasisURL;
+            Logger.log("iframe loading oasis");
+            iframe.contentWindow.location.href = oasisURL;
+          });
         };
         addEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
@@ -1017,9 +1034,10 @@ define("oasis",
             if( event.source !== iframe.contentWindow ) {return;}
             removeEventListener(window, 'message', iframe.initializationHandler);
 
-
-            Logger.log("iframe sandbox initialized");
-            resolve(sandbox);
+            configuration.eventCallback(function () {
+              Logger.log("iframe sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(window, 'message', iframe.initializationHandler);
         });
@@ -1033,8 +1051,10 @@ define("oasis",
             if( event.source !== iframe.contentWindow ) {return;}
             removeEventListener(window, 'message', iframe.loadHandler);
 
-            Logger.log("iframe sandbox loaded");
-            resolve(sandbox);
+            configuration.eventCallback(function () {
+              Logger.log("iframe sandbox loaded");
+              resolve(sandbox);
+            });
           };
           addEventListener(window, 'message', iframe.loadHandler);
         });
@@ -1140,12 +1160,13 @@ define("oasis",
 
     return logger;
   });define("oasis/message_channel",
-  ["oasis/util", "rsvp", "oasis/state", "exports"],
-  function(__dependency1__, RSVP, OasisState, __exports__) {
+  ["oasis/util", "oasis/config", "rsvp", "oasis/state", "exports"],
+  function(__dependency1__, __dependency2__, RSVP, OasisState, __exports__) {
     "use strict";
     var extend = __dependency1__.extend;
     var mustImplement = __dependency1__.mustImplement;
     var rsvpErrorHandler = __dependency1__.rsvpErrorHandler;
+    var configuration = __dependency2__.configuration;
 
     /**
       OasisPort is an interface that adapters can use to implement ports.
@@ -1356,7 +1377,9 @@ define("oasis",
       on: function(eventName, callback, binding) {
         function wrappedCallback(event) {
           if (event.data.type === eventName) {
-            callback.call(binding, event.data.data);
+            configuration.eventCallback(function () {
+              return callback.call(binding, event.data.data);
+            });
           }
         }
 
@@ -1365,9 +1388,13 @@ define("oasis",
       },
 
       all: function(callback, binding) {
-        this.port.addEventListener('message', function(event) {
-          callback.call(binding, event.data.type, event.data.data);
-        });
+        function wrappedCallback(event) {
+          configuration.eventCallback(function () {
+            callback.call(binding, event.data.type, event.data.data);
+          });
+        }
+
+        this.port.addEventListener('message', wrappedCallback);
       },
 
       off: function(eventName, callback) {
@@ -1409,14 +1436,15 @@ define("oasis",
     __exports__.PostMessageMessageChannel = PostMessageMessageChannel;
     __exports__.PostMessagePort = PostMessagePort;
   });define("oasis/sandbox",
-  ["oasis/util", "oasis/shims", "oasis/message_channel", "rsvp", "oasis/logger", "oasis/state", "oasis/config", "oasis/iframe_adapter"],
-  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, State, configuration, iframeAdapter) {
+  ["oasis/util", "oasis/shims", "oasis/message_channel", "oasis/config", "rsvp", "oasis/logger", "oasis/state", "oasis/iframe_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, __dependency4__, RSVP, Logger, State, iframeAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
     var rsvpErrorHandler = __dependency1__.rsvpErrorHandler;
     var a_forEach = __dependency2__.a_forEach;
     var a_reduce = __dependency2__.a_reduce;
     var OasisPort = __dependency3__.OasisPort;
+    var configuration = __dependency4__.configuration;
 
 
     var OasisSandbox = function(options) {
@@ -1960,9 +1988,11 @@ define("oasis",
     __exports__.addEventListener = addEventListener;
     __exports__.removeEventListener = removeEventListener;
   });define("oasis/state",
-  [],
-  function() {
+  ["oasis/config"],
+  function(__dependency1__) {
     "use strict";
+    var configuration = __dependency1__.configuration;
+
     function State () {
       this.reset();
     };
@@ -1974,6 +2004,8 @@ define("oasis",
 
       this.consumers = {};
       this.services = [];
+
+      configuration.eventCallback = function (callback) { callback(); };
     }
 
     return new State;
@@ -2040,13 +2072,14 @@ define("oasis",
     __exports__.verifySandbox = verifySandbox;
     __exports__.rsvpErrorHandler = rsvpErrorHandler;
   });define("oasis/webworker_adapter",
-  ["oasis/util", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
-  function(__dependency1__, __dependency2__, RSVP, Logger, BaseAdapter) {
+  ["oasis/util", "oasis/config", "oasis/shims", "rsvp", "oasis/logger", "oasis/base_adapter"],
+  function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, BaseAdapter) {
     "use strict";
     var extend = __dependency1__.extend;
-    var a_forEach = __dependency2__.a_forEach;
-    var addEventListener = __dependency2__.addEventListener;
-    var removeEventListener = __dependency2__.removeEventListener;
+    var configuration = __dependency2__.configuration;
+    var a_forEach = __dependency3__.a_forEach;
+    var addEventListener = __dependency3__.addEventListener;
+    var removeEventListener = __dependency3__.removeEventListener;
 
 
     var WebworkerAdapter = extend(BaseAdapter, {
@@ -2057,22 +2090,26 @@ define("oasis",
 
         sandbox.promise = new RSVP.Promise( function(resolve, reject) {
           worker.initializationHandler = function (event) {
-            if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
-            removeEventListener(worker, 'message', worker.initializationHandler);
+            configuration.eventCallback(function () {
+              if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
+              removeEventListener(worker, 'message', worker.initializationHandler);
 
-            Logger.log("worker sandbox initialized");
-            resolve(sandbox);
+              Logger.log("worker sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(worker, 'message', worker.initializationHandler);
         });
 
         return new RSVP.Promise(function (resolve, reject) {
           worker.loadHandler = function (event) {
-            if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
-            removeEventListener(worker, 'message', worker.loadHandler);
+            configuration.eventCallback(function () {
+              if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
+              removeEventListener(worker, 'message', worker.loadHandler);
 
-            Logger.log("worker sandbox initialized");
-            resolve(sandbox);
+              Logger.log("worker sandbox initialized");
+              resolve(sandbox);
+            });
           };
           addEventListener(worker, 'message', worker.loadHandler);
         });

--- a/lib/oasis.js
+++ b/lib/oasis.js
@@ -2,7 +2,7 @@ import "rsvp" as RSVP;
 import "oasis/logger" as Logger;
 import { assert, verifySandbox } from "oasis/util";
 import "oasis/state" as State;
-import "oasis/config" as configuration;
+import { configuration, configure } from "oasis/config";
 import "oasis/sandbox" as Sandbox;
 import "oasis/sandbox_init" as initializeSandbox;
 
@@ -53,6 +53,7 @@ Oasis.reset = function() {
 Oasis.reset();
 
 Oasis.config = configuration;
+Oasis.configure = configure;
 
 
 /**

--- a/lib/oasis/base_adapter.js
+++ b/lib/oasis/base_adapter.js
@@ -2,7 +2,7 @@ import "oasis/logger" as Logger;
 import { mustImplement } from "oasis/util";
 import { addEventListener, removeEventListener } from "oasis/shims";
 
-import "oasis/config" as configuration;
+import { configuration } from "oasis/config";
 import { handlers } from "oasis/globals";
 import { connectCapabilities } from "oasis/connect";
 import { PostMessageMessageChannel } from "oasis/message_channel";
@@ -54,16 +54,18 @@ BaseAdapter.prototype = {
     function initializeOasisSandbox(event) {
       if (!event.data.isOasisInitialization) { return; }
 
-      Logger.log("Sandbox initializing.");
+      configuration.eventCallback(function () {
+        Logger.log("Sandbox initializing.");
 
-      configuration.oasisURL = event.data.oasisURL;
+        configuration.oasisURL = event.data.oasisURL;
 
-      removeEventListener(receiver, 'message', initializeOasisSandbox);
-      adapter.loadScripts(event.data.base, event.data.scriptURLs);
+        removeEventListener(receiver, 'message', initializeOasisSandbox);
+        adapter.loadScripts(event.data.base, event.data.scriptURLs);
 
-      connectCapabilities(event.data.capabilities, event.ports);
+        connectCapabilities(event.data.capabilities, event.ports);
 
-      adapter.didConnect();
+        adapter.didConnect();
+      });
     }
     addEventListener(receiver, 'message', initializeOasisSandbox);
 

--- a/lib/oasis/config.js
+++ b/lib/oasis/config.js
@@ -1,9 +1,16 @@
 /**
   Stores Oasis configuration.  Options include:
 
-  `oasisURL` - the default URL to use for sandboxes.
+  - `oasisURL` - the default URL to use for sandboxes.
+  - `eventCallback` - a function that wraps `message` event handlers.  By
+    default the event hanlder is simply invoked.
 */
 var configuration = {
+  eventCallback: function (callback) { callback(); }
 };
 
-export = configuration;
+function configure(name, value) {
+  configuration[name] = value;
+}
+
+export { configuration, configure };

--- a/lib/oasis/iframe_adapter.js
+++ b/lib/oasis/iframe_adapter.js
@@ -1,6 +1,7 @@
 import "rsvp" as RSVP;
 import "oasis/logger" as Logger;
 import { extend } from "oasis/util";
+import { configuration } from "oasis/config";
 import { addEventListener, removeEventListener, a_map } from "oasis/shims";
 
 import "oasis/base_adapter" as BaseAdapter;
@@ -24,12 +25,14 @@ var IframeAdapter = extend(BaseAdapter, {
     }
 
     iframe.oasisLoadHandler = function () {
-      removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
+      configuration.eventCallback(function () {
+        removeEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
-      sandbox.iframeLoaded = true;
+        sandbox.iframeLoaded = true;
 
-      Logger.log("iframe loading oasis");
-      iframe.contentWindow.location.href = oasisURL;
+        Logger.log("iframe loading oasis");
+        iframe.contentWindow.location.href = oasisURL;
+      });
     };
     addEventListener(iframe, 'load', iframe.oasisLoadHandler);
 
@@ -40,9 +43,10 @@ var IframeAdapter = extend(BaseAdapter, {
         if( event.source !== iframe.contentWindow ) {return;}
         removeEventListener(window, 'message', iframe.initializationHandler);
 
-
-        Logger.log("iframe sandbox initialized");
-        resolve(sandbox);
+        configuration.eventCallback(function () {
+          Logger.log("iframe sandbox initialized");
+          resolve(sandbox);
+        });
       };
       addEventListener(window, 'message', iframe.initializationHandler);
     });
@@ -56,8 +60,10 @@ var IframeAdapter = extend(BaseAdapter, {
         if( event.source !== iframe.contentWindow ) {return;}
         removeEventListener(window, 'message', iframe.loadHandler);
 
-        Logger.log("iframe sandbox loaded");
-        resolve(sandbox);
+        configuration.eventCallback(function () {
+          Logger.log("iframe sandbox loaded");
+          resolve(sandbox);
+        });
       };
       addEventListener(window, 'message', iframe.loadHandler);
     });

--- a/lib/oasis/message_channel.js
+++ b/lib/oasis/message_channel.js
@@ -1,5 +1,6 @@
 import "rsvp" as RSVP;
 import { extend, mustImplement, rsvpErrorHandler } from "oasis/util";
+import { configuration } from "oasis/config";
 import "oasis/state" as OasisState;
 
 /**
@@ -211,7 +212,9 @@ var PostMessagePort = extend(OasisPort, {
   on: function(eventName, callback, binding) {
     function wrappedCallback(event) {
       if (event.data.type === eventName) {
-        callback.call(binding, event.data.data);
+        configuration.eventCallback(function () {
+          return callback.call(binding, event.data.data);
+        });
       }
     }
 
@@ -220,9 +223,13 @@ var PostMessagePort = extend(OasisPort, {
   },
 
   all: function(callback, binding) {
-    this.port.addEventListener('message', function(event) {
-      callback.call(binding, event.data.type, event.data.data);
-    });
+    function wrappedCallback(event) {
+      configuration.eventCallback(function () {
+        callback.call(binding, event.data.type, event.data.data);
+      });
+    }
+
+    this.port.addEventListener('message', wrappedCallback);
   },
 
   off: function(eventName, callback) {

--- a/lib/oasis/sandbox.js
+++ b/lib/oasis/sandbox.js
@@ -5,7 +5,7 @@ import { a_forEach, a_reduce} from "oasis/shims";
 
 import { OasisPort } from "oasis/message_channel";
 import "oasis/state" as State;
-import "oasis/config" as configuration;
+import { configuration } from "oasis/config";
 import "oasis/iframe_adapter" as iframeAdapter;
 
 var OasisSandbox = function(options) {

--- a/lib/oasis/state.js
+++ b/lib/oasis/state.js
@@ -1,3 +1,5 @@
+import { configuration } from "oasis/config";
+
 function State () {
   this.reset();
 };
@@ -9,6 +11,8 @@ State.prototype.reset = function () {
 
   this.consumers = {};
   this.services = [];
+
+  configuration.eventCallback = function (callback) { callback(); };
 }
 
 export = new State;

--- a/lib/oasis/webworker_adapter.js
+++ b/lib/oasis/webworker_adapter.js
@@ -1,6 +1,7 @@
 import "rsvp" as RSVP;
 import "oasis/logger" as Logger;
 import { extend } from "oasis/util";
+import { configuration } from "oasis/config";
 import { a_forEach, addEventListener, removeEventListener } from "oasis/shims";
 
 import "oasis/base_adapter" as BaseAdapter;
@@ -13,22 +14,26 @@ var WebworkerAdapter = extend(BaseAdapter, {
 
     sandbox.promise = new RSVP.Promise( function(resolve, reject) {
       worker.initializationHandler = function (event) {
-        if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
-        removeEventListener(worker, 'message', worker.initializationHandler);
+        configuration.eventCallback(function () {
+          if( event.data !== sandbox.adapter.sandboxInitializedMessage ) {return;}
+          removeEventListener(worker, 'message', worker.initializationHandler);
 
-        Logger.log("worker sandbox initialized");
-        resolve(sandbox);
+          Logger.log("worker sandbox initialized");
+          resolve(sandbox);
+        });
       };
       addEventListener(worker, 'message', worker.initializationHandler);
     });
 
     return new RSVP.Promise(function (resolve, reject) {
       worker.loadHandler = function (event) {
-        if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
-        removeEventListener(worker, 'message', worker.loadHandler);
+        configuration.eventCallback(function () {
+          if( event.data !== sandbox.adapter.oasisLoadedMessage ) {return;}
+          removeEventListener(worker, 'message', worker.loadHandler);
 
-        Logger.log("worker sandbox initialized");
-        resolve(sandbox);
+          Logger.log("worker sandbox initialized");
+          resolve(sandbox);
+        });
       };
       addEventListener(worker, 'message', worker.loadHandler);
     });

--- a/test/fixtures/environment_wrapped_event_callbacks.js
+++ b/test/fixtures/environment_wrapped_event_callbacks.js
@@ -1,0 +1,3 @@
+Oasis.connect('wrappedEvents').then(function (port) {
+  port.send('wrapMe');
+});

--- a/test/fixtures/inception_child.js
+++ b/test/fixtures/inception_child.js
@@ -1,5 +1,5 @@
 Oasis.connect('inception', function(port) {
-  port.request('kick').then(function() {
-    port.send('workPlacement');
+  port.request('kick').then(function(value) {
+    port.send('workPlacement', value);
   });
 });

--- a/test/fixtures/sandbox_wrapped_event_callbacks.js
+++ b/test/fixtures/sandbox_wrapped_event_callbacks.js
@@ -1,0 +1,24 @@
+var inWrapper = false;
+
+Oasis.configure('eventCallback', function (callback) {
+  inWrapper = true;
+  callback();
+  inWrapper = false;
+});
+
+Oasis.connect({
+  consumers: {
+    wrappedEvents: Oasis.Consumer.extend({
+      initialize: function (port) {
+        port.all( function () {
+          port.send('wiretapResult', inWrapper);
+        }, this);
+      },
+      events: {
+        wrapMe: function () {
+          this.send('eventResult', inWrapper);
+        }
+      }
+    })
+  }
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -799,12 +799,12 @@ function suite(adapter, extras) {
       var InceptionService = Oasis.Service.extend({
         initialize: function(port) {
           port.onRequest('kick', function() {
-            return 'kick';
+            return 'kick1';
           });
 
-          port.on('workPlacement', function() {
+          port.on('workPlacement', function(value) {
             start();
-            ok(true, "messages between deeply nested sandboxes are sent");
+            equal(value, 'kick1', "messages between deeply nested sandboxes are sent");
           });
         }
       });
@@ -833,14 +833,14 @@ function suite(adapter, extras) {
         requests: {
           kick: function() {
             ok(this instanceof InceptionService, "The callback gets the service instance as `this`");
-            return 'kick';
+            return 'kick2';
           }
         },
 
         events: {
-          workPlacement: function() {
+          workPlacement: function(value) {
             start();
-            ok(true, "messages between deeply nested sandboxes are sent");
+            equal(value, 'kick2', "messages between deeply nested sandboxes are sent");
             ok(this instanceof InceptionService, "The callback gets the service instance as `this`");
           }
         }


### PR DESCRIPTION
Users may specify their own event handler wrappers via:
```js Oasis.configure('eventHandler', function (callback) { callback(); });

```

https://trello.com/card/add-the-ability-to-wrap-message-events-in-oasis-so-that-when-using-it-with-ember-we-can-wrap-them-in-a-run-loop/51a8c7c06d8a1a70030000dc/19
```
