### PR TITLE
Save services and ports in `sandbox.capabilities` by capability name.

### DIFF
--- a/History.md
+++ b/History.md
@@ -4,7 +4,7 @@
 ```js
   sandbox.promise.then(function () {
     // This only works for non-transfered ports
-    sandbox.ports.someCapability.send('something');
+    sandbox.capabilities.someCapability.send('something');
   });
 ```
 - Users may supply wrappers around event handlers via `Oasis.configure`.  The

--- a/dist/oasis.js.html
+++ b/dist/oasis.js.html
@@ -842,7 +842,7 @@ define("rsvp",
 
         return {
           isOasisInitialization: true,
-          capabilities: sandbox.capabilities,
+          capabilities: sandbox._capabilitiesToConnect,
           base: getBase(),
           scriptURLs: scriptURLs,
           oasisURL: this.oasisURL(sandbox)
@@ -1539,16 +1539,16 @@ define("rsvp",
 
       var adapter = this.adapter = options.adapter || iframeAdapter;
 
-      this.capabilities = capabilities;
+      this._capabilitiesToConnect = capabilities;
       this.envPortDefereds = {};
       this.sandboxPortDefereds = {};
       this.channels = {};
-      this.ports = {};
+      this.capabilities = {};
       this.options = options;
 
       var loadPromise = adapter.initializeSandbox(this);
 
-      a_forEach.call(this.capabilities, function(capability) {
+      a_forEach.call(capabilities, function(capability) {
         this.envPortDefereds[capability] = RSVP.defer();
         this.sandboxPortDefereds[capability] = RSVP.defer();
       }, this);
@@ -1577,7 +1577,7 @@ define("rsvp",
         var sandbox = this,
             services = this.options.services || {},
             channels = this.channels;
-        a_forEach.call(this.capabilities, function (capability) {
+        a_forEach.call(this._capabilitiesToConnect, function (capability) {
 
           Logger.log("Will create port for '" + capability + "'");
           var service = services[capability],
@@ -1589,6 +1589,7 @@ define("rsvp",
           // TODO: This should probably be an OasisPort if possible
           if (service instanceof OasisPort) {
             port = this.adapter.proxyPort(this, service);
+            this.capabilities[capability] = service;
           } else {
             channel = channels[capability] = this.adapter.createChannel();
 
@@ -1628,12 +1629,12 @@ define("rsvp",
               service = new service(environmentPort, this);
               service.initialize(environmentPort, capability);
               State.services.push(service);
+              this.capabilities[capability] = service;
             }
 
             // Law of Demeter violation
             port = sandboxPort;
 
-            this.ports[capability] = environmentPort;
             this.envPortDefereds[capability].resolve(environmentPort);
           }
 
@@ -1653,7 +1654,7 @@ define("rsvp",
       connectPorts: function () {
         var sandbox = this;
 
-        var allSandboxPortPromises = a_reduce.call(this.capabilities, function (accumulator, capability) {
+        var allSandboxPortPromises = a_reduce.call(this._capabilitiesToConnect, function (accumulator, capability) {
           return accumulator.concat(sandbox.sandboxPortDefereds[capability].promise);
         }, []);
 

--- a/lib/oasis/base_adapter.js
+++ b/lib/oasis/base_adapter.js
@@ -79,7 +79,7 @@ BaseAdapter.prototype = {
 
     return {
       isOasisInitialization: true,
-      capabilities: sandbox.capabilities,
+      capabilities: sandbox._capabilitiesToConnect,
       base: getBase(),
       scriptURLs: scriptURLs,
       oasisURL: this.oasisURL(sandbox)

--- a/lib/oasis/sandbox.js
+++ b/lib/oasis/sandbox.js
@@ -27,16 +27,16 @@ var OasisSandbox = function(options) {
 
   var adapter = this.adapter = options.adapter || iframeAdapter;
 
-  this.capabilities = capabilities;
+  this._capabilitiesToConnect = capabilities;
   this.envPortDefereds = {};
   this.sandboxPortDefereds = {};
   this.channels = {};
-  this.ports = {};
+  this.capabilities = {};
   this.options = options;
 
   var loadPromise = adapter.initializeSandbox(this);
 
-  a_forEach.call(this.capabilities, function(capability) {
+  a_forEach.call(capabilities, function(capability) {
     this.envPortDefereds[capability] = RSVP.defer();
     this.sandboxPortDefereds[capability] = RSVP.defer();
   }, this);
@@ -65,7 +65,7 @@ OasisSandbox.prototype = {
     var sandbox = this,
         services = this.options.services || {},
         channels = this.channels;
-    a_forEach.call(this.capabilities, function (capability) {
+    a_forEach.call(this._capabilitiesToConnect, function (capability) {
 
       Logger.log("Will create port for '" + capability + "'");
       var service = services[capability],
@@ -77,6 +77,7 @@ OasisSandbox.prototype = {
       // TODO: This should probably be an OasisPort if possible
       if (service instanceof OasisPort) {
         port = this.adapter.proxyPort(this, service);
+        this.capabilities[capability] = service;
       } else {
         channel = channels[capability] = this.adapter.createChannel();
 
@@ -116,12 +117,12 @@ OasisSandbox.prototype = {
           service = new service(environmentPort, this);
           service.initialize(environmentPort, capability);
           State.services.push(service);
+          this.capabilities[capability] = service;
         }
 
         // Law of Demeter violation
         port = sandboxPort;
 
-        this.ports[capability] = environmentPort;
         this.envPortDefereds[capability].resolve(environmentPort);
       }
 
@@ -141,7 +142,7 @@ OasisSandbox.prototype = {
   connectPorts: function () {
     var sandbox = this;
 
-    var allSandboxPortPromises = a_reduce.call(this.capabilities, function (accumulator, capability) {
+    var allSandboxPortPromises = a_reduce.call(this._capabilitiesToConnect, function (accumulator, capability) {
       return accumulator.concat(sandbox.sandboxPortDefereds[capability].promise);
     }, []);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,7 +1,6 @@
 (function() {
 
-QUnit.config.testTimeout = QUnit.config.testTimeout || 5000;
-// QUnit.config.testTimeout = 1000 * 60 * 2;
+QUnit.config.testTimeout = 15000;
 
 module("Oasis");
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -784,7 +784,7 @@ function suite(adapter, extras) {
     sandbox.start();
   });
 
-  test("sandboxes have access to ports & services via `sandbox.ports`", function() {
+  test("sandboxes have access to ports & services via `sandbox.capabilities`", function() {
     expect(2);
     stop(2);
 
@@ -796,11 +796,11 @@ function suite(adapter, extras) {
           events: {
             somethingOkay: function () {
               start();
-              ok(true, "sandbox.ports could be used to send messages to named services");
+              ok(true, "sandbox.capabilities could be used to send messages to named services");
             },
             somethingElseOkay: function () {
               start();
-              ok(true, "sandbox.ports could be used to send messages to named services");
+              ok(true, "sandbox.capabilities could be used to send messages to named services");
             }
           }
         }),
@@ -810,8 +810,38 @@ function suite(adapter, extras) {
     });
 
     sandbox.promise.then(function () {
-      sandbox.ports.something.send('go');
-      sandbox.ports.somethingElse.send('go');
+      sandbox.capabilities.something.send('go');
+      sandbox.capabilities.somethingElse.send('go');
+    });
+
+    sandbox.start();
+  });
+
+  test("sandboxes have access to services via `sandbox.capabilities`", function() {
+    expect(2);
+    stop();
+
+    var LocalService = Oasis.Service.extend({ }),
+        adapter = Oasis.adapters[sharedAdapter],
+        channel = adapter.createChannel(),
+        port = channel.port2;
+
+    createSandbox({
+      url: 'fixtures/index.js',
+      capabilities: ['serviceCapability', 'portCapability'],
+      services: {
+        serviceCapability: LocalService,
+        portCapability: port
+      }
+    });
+
+    sandbox.promise.then(function () {
+      var capabilities = sandbox.capabilities;
+
+      ok(capabilities.serviceCapability instanceof LocalService, "The capability has an associated service");
+      equal(capabilities.portCapability, port, "The capability has an associated port");
+
+      start();
     });
 
     sandbox.start();

--- a/test/tests.js
+++ b/test/tests.js
@@ -1237,6 +1237,7 @@ function suite(adapter, extras) {
 
   test("Sandboxes can ask for ports directly via portFor", function() {
     expect(3);
+    stop(2);
 
     var AssertionService = Oasis.Service.extend({
       events: {
@@ -1263,9 +1264,6 @@ function suite(adapter, extras) {
         assertions: AssertionService
       }
     });
-
-    stop();
-    stop();
 
     sandbox.start();
   });
@@ -1336,9 +1334,6 @@ function suite(adapter, extras) {
       capabilities: ['wrappedEvents'],
       services: {
         wrappedEvents: Oasis.Service.extend({
-          initialize: function (port) {
-            this.sandbox.port = port;
-          },
           events: {
             wiretapResult: function (result) {
               start();
@@ -1354,7 +1349,7 @@ function suite(adapter, extras) {
     });
 
     sandbox.promise.then(function (sandbox) {
-      sandbox.port.send('wrapMe');
+      sandbox.capabilities.wrappedEvents.send('wrapMe');
     });
 
     sandbox.start();
@@ -1363,8 +1358,7 @@ function suite(adapter, extras) {
   test("environment event callbacks can be wrapped", function() {
     var inWrapper = false;
     expect(2);
-    stop();
-    stop();
+    stop(2);
 
     Oasis.configure('eventCallback', function (callback) {
       inWrapper = true;
@@ -1409,11 +1403,11 @@ suite('iframe', function() {
     });
 
     ok(sandbox.el instanceof window.HTMLIFrameElement, "A new iframe was returned");
-
-    sandbox.start();
   });
 
   test("Sandboxes can post messages to their own nested (non-Oasis) iframes", function() {
+    stop();
+
     var sandboxUrl = destinationUrl +  "/fixtures/same_origin.js";
 
     Oasis.register({
@@ -1429,8 +1423,6 @@ suite('iframe', function() {
         }
       }
     });
-
-    stop();
 
     createSandbox({
       url: sandboxUrl,
@@ -1463,11 +1455,11 @@ suite('iframe', function() {
   test("Sandboxes ignore secondary initialization messages", function() {
     // If the second initialization message runs, two 'ok' events will be sent.
     expect(1);
+    stop();
 
     var AssertionsService = Oasis.Service.extend({
       events: {
         ok: function (data) {
-          start();
           equal(data, 'success', "Sandbox communicated.");
 
           sandbox.el.contentWindow.postMessage({
@@ -1476,6 +1468,8 @@ suite('iframe', function() {
             base: getBase(),
             scriptURLs: ['fixtures/assertions.js']
           }, '*');
+
+          start();
         }
       }
     });
@@ -1488,7 +1482,6 @@ suite('iframe', function() {
       }
     });
 
-    stop();
     sandbox.start();
   });
 });


### PR DESCRIPTION
- the associated objet can be a service or a port
- Ports are usable after the sandbox promise resolves.
