### PR TITLE
Improve security model for non sandboxed iframes.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -40,9 +40,15 @@ module.exports = function(grunt) {
         }
       },
 
-      otherDomain: {
+      childServer: {
         options: {
           port: 8001
+        }
+      },
+
+      grandChildServer: {
+        options: {
+          port: 8003
         }
       }
     },

--- a/dist/oasis.js.html
+++ b/dist/oasis.js.html
@@ -676,7 +676,6 @@ define("rsvp",
   function(__dependency1__, __dependency2__, __dependency3__, RSVP, Logger, State, Sandbox, initializeSandbox, Service, iframeAdapter, webworkerAdapter) {
     "use strict";
     var assert = __dependency1__.assert;
-    var verifySandbox = __dependency1__.verifySandbox;
     var configuration = __dependency2__.configuration;
     var configure = __dependency2__.configure;
     var registerHandler = __dependency3__.registerHandler;
@@ -861,9 +860,11 @@ define("rsvp",
       - `oasisURL` - the default URL to use for sandboxes.
       - `eventCallback` - a function that wraps `message` event handlers.  By
         default the event hanlder is simply invoked.
+      - `allowSameOrigin` - a card can be hosted on the same domain
     */
     var configuration = {
-      eventCallback: function (callback) { callback(); }
+      eventCallback: function (callback) { callback(); },
+      allowSameOrigin: false
     };
 
     function configure(name, value) {
@@ -1073,11 +1074,29 @@ define("rsvp",
     var a_map = __dependency3__.a_map;
 
 
+    function verifySandbox(sandboxUrl) {
+      var iframe = document.createElement('iframe'),
+          link;
+
+      if( !configuration.allowSameOrigin && iframe.sandbox === undefined ) {
+        // The sandbox attribute isn't supported,
+        // we need to make sure the sandbox is loaded from a separate domain
+        link = document.createElement('a');
+        link.href = sandboxUrl;
+
+        if( !link.host || (link.protocol === window.location.protocol && link.host === window.location.host) ) {
+          throw "Loading an iframe from the same host is a potential security breach";
+        }
+      }
+    }
+
     var IframeAdapter = extend(BaseAdapter, {
       initializeSandbox: function(sandbox) {
         var options = sandbox.options,
             iframe = document.createElement('iframe'),
             oasisURL = this.oasisURL(sandbox);
+
+        verifySandbox( oasisURL );
 
         iframe.name = sandbox.options.url;
         iframe.sandbox = 'allow-scripts';

--- a/lib/oasis.js
+++ b/lib/oasis.js
@@ -1,6 +1,6 @@
 import "rsvp" as RSVP;
 import "oasis/logger" as Logger;
-import { assert, verifySandbox } from "oasis/util";
+import { assert } from "oasis/util";
 import "oasis/state" as State;
 import { configuration, configure } from "oasis/config";
 import "oasis/sandbox" as Sandbox;

--- a/lib/oasis/config.js
+++ b/lib/oasis/config.js
@@ -4,9 +4,11 @@
   - `oasisURL` - the default URL to use for sandboxes.
   - `eventCallback` - a function that wraps `message` event handlers.  By
     default the event hanlder is simply invoked.
+  - `allowSameOrigin` - a card can be hosted on the same domain
 */
 var configuration = {
-  eventCallback: function (callback) { callback(); }
+  eventCallback: function (callback) { callback(); },
+  allowSameOrigin: false
 };
 
 function configure(name, value) {

--- a/lib/oasis/iframe_adapter.js
+++ b/lib/oasis/iframe_adapter.js
@@ -6,11 +6,29 @@ import { addEventListener, removeEventListener, a_map } from "oasis/shims";
 
 import "oasis/base_adapter" as BaseAdapter;
 
+function verifySandbox(sandboxUrl) {
+  var iframe = document.createElement('iframe'),
+      link;
+
+  if( !configuration.allowSameOrigin && iframe.sandbox === undefined ) {
+    // The sandbox attribute isn't supported,
+    // we need to make sure the sandbox is loaded from a separate domain
+    link = document.createElement('a');
+    link.href = sandboxUrl;
+
+    if( !link.host || (link.protocol === window.location.protocol && link.host === window.location.host) ) {
+      throw "Loading an iframe from the same host is a potential security breach";
+    }
+  }
+}
+
 var IframeAdapter = extend(BaseAdapter, {
   initializeSandbox: function(sandbox) {
     var options = sandbox.options,
         iframe = document.createElement('iframe'),
         oasisURL = this.oasisURL(sandbox);
+
+    verifySandbox( oasisURL );
 
     iframe.name = sandbox.options.url;
     iframe.sandbox = 'allow-scripts';

--- a/test/fixtures/inception_parent.js
+++ b/test/fixtures/inception_parent.js
@@ -1,3 +1,5 @@
+var destinationUrl = window.location.protocol + "//" + window.location.hostname + ":" + (parseInt(window.location.port, 10) + 2);
+
 Oasis.connect('inception', function(port) {
   Oasis.register({
     url: 'fixtures/inception_child.js',
@@ -8,7 +10,8 @@ Oasis.connect('inception', function(port) {
     url: "fixtures/inception_child.js",
     services: {
       inception: port
-    }
+    },
+    oasisURL: destinationUrl + '/oasis.js.html'
   });
 
   sandbox.start();

--- a/test/fixtures/nested_custom_oasis_url_parent.js
+++ b/test/fixtures/nested_custom_oasis_url_parent.js
@@ -1,3 +1,5 @@
+Oasis.config.allowSameOrigin = true;
+
 Oasis.connect('assertions', function(port) {
   Oasis.register({
     url: 'fixtures/nested_custom_oasis_url_child.js',

--- a/test/tests.js
+++ b/test/tests.js
@@ -23,6 +23,7 @@ function suite(adapter, extras) {
   module("Oasis.createSandbox (for the " + adapter + " adapter)", {
     setup: function() {
       sharedAdapter = adapter;
+      Oasis.config.allowSameOrigin = false;
     },
 
     teardown: function() {
@@ -952,7 +953,7 @@ function suite(adapter, extras) {
         services: {
           assertions: AssertionService
         },
-        oasisURL: '/vendor/oasis-custom-url.js.html'
+        oasisURL: destinationUrl + '/vendor/oasis-custom-url.js.html'
       });
 
       stop();
@@ -1402,6 +1403,18 @@ suite('iframe', function() {
     });
 
     ok(sandbox.el instanceof window.HTMLIFrameElement, "A new iframe was returned");
+  });
+
+  test("A card can be loaded from the same domain with `Oasis.config.allowSameOrigin` sets to true", function() {
+    Oasis.config.allowSameOrigin = true;
+
+    createSandbox({
+      url: "fixtures/index.js",
+      capabilities: [],
+      oasisURL: "/oasis.js.html"
+    });
+
+    ok(true, "Oasis can be loaded from the same domain");
   });
 
   test("Sandboxes can post messages to their own nested (non-Oasis) iframes", function() {


### PR DESCRIPTION
Oasis ensures that iframes are loaded from a separate domain
if the browser does not support the `sandbox` attribute.

This restriction can be avoided by setting
`Oasis.config.allowSameOrigin` to true.
