### PR TITLE
fix opening example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Here is what your application would look like:
         });
       });
 
-      document.body.appendChild(sandbox);
+      document.body.appendChild(sandbox.el);
     </script>
   </body>
 </html>


### PR DESCRIPTION
document.body.appendChild(sandbox);
should be
document.body.appendChild(sandbox.el);

and then the opening example in the README works as expected
